### PR TITLE
Add support for running `sync` and `clean` on diffs of BibTeX instead of the whole thing

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,14 +1,10 @@
 name: "Sync Paperpile to Notion"
 
 on:
-  workflow_call:
-    inputs:
-      references:
-        required: true
-        type: "string"
-    secrets:
-      token:
-        required: true
+  workflow_dispatch: { }
+  push:
+    paths:
+      - "**.bib"
 
 jobs:
   sync-to-notion:
@@ -18,14 +14,26 @@ jobs:
 
     concurrency:
       group: "paperpile-sync"
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v3"
 
+      - name: "Checkout repository again to retrieve old references"
+        uses: "actions/checkout@v3"
+        with:
+          path: "prev/"
+          fetch-depth: 2
+
+      - name: "Retrieve old references"
+        shell: "bash"
+        run: |
+          git checkout HEAD~1
+
       - name: "Run `paperpile-notion` sync"
         uses: "jmuchovej/paperpile-notion@latest"
         with:
-          references: "${{ inputs.references }}"
-          token: "${{ secrets.token }}"
+          references: "references.bib"
+          token: "${{ secrets.NOTION_INTEGRATION_TOKEN }}"
+          references-diff: "prev/references.bib"

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,9 @@ inputs:
   token:
     description: "Your Notion Integration Token."
     required: true
+  references-diff:
+    description: "Sync `diff`s instead of running a full-sync everytime Paperpile syncs your changes."
+    required: false
 
 runs:
   using: "composite"
@@ -40,13 +43,23 @@ runs:
       shell: "bash"
       env:
         DEBUG: "@jitl/notion-api:cms:cache,@jtil/notion-api:children,@jitl/notion-api:iterate"
-      run: "paperpile-notion authors:sync ${{ inputs.references }} -t ${{ inputs.token }}"
+      run: |
+        if [ -z "${{ inputs.references-diff }}" ]; then
+          paperpile-notion authors:sync ${{ inputs.references }} -t ${{ inputs.token }}
+        else
+          paperpile-notion authors:sync ${{ inputs.references }} -t ${{ inputs.token }} -d ${{ inputs.references-diff }}
+        fi
 
     - name: "Sync Article's Database"
       shell: "bash"
       env:
         DEBUG: "@jitl/notion-api:cms:cache,@jtil/notion-api:children,@jitl/notion-api:iterate"
-      run: "paperpile-notion articles:sync ${{ inputs.references }} -t ${{ inputs.token }}"
+      run: |
+        if [ -z "${{ inputs.references-diff }}" ]; then
+          paperpile-notion articles:sync ${{ inputs.references }} -t ${{ inputs.token }}
+        else
+          paperpile-notion articles:sync ${{ inputs.references }} -t ${{ inputs.token }} -d ${{ inputs.references-diff }}
+        fi
 
     - name: "Clean Author's Database"
       shell: "bash"

--- a/action.yaml
+++ b/action.yaml
@@ -11,10 +11,10 @@ inputs:
     description: "The path to your BibTeX containing the desired entries to sync"
     required: true
   token:
-    description: "Your Notion Integration Token."
+    description: "Your Notion Integration Token"
     required: true
   references-diff:
-    description: "Sync `diff`s instead of running a full-sync everytime Paperpile syncs your changes."
+    description: "The path to your BibTeX to `diff` against"
     required: false
 
 runs:
@@ -44,34 +44,28 @@ runs:
       env:
         DEBUG: "@jitl/notion-api:cms:cache,@jtil/notion-api:children,@jitl/notion-api:iterate"
       run: |
-        if [ -z "${{ inputs.references-diff }}" ]; then
-          paperpile-notion authors:sync ${{ inputs.references }} -t ${{ inputs.token }}
-        else
-          paperpile-notion authors:sync ${{ inputs.references }} -t ${{ inputs.token }} -d ${{ inputs.references-diff }}
-        fi
+        paperpile-notion authors:sync ${{ inputs.references }} ${{ inputs.references-diff }} -t ${{ inputs.token }}
 
     - name: "Sync Article's Database"
       shell: "bash"
       env:
         DEBUG: "@jitl/notion-api:cms:cache,@jtil/notion-api:children,@jitl/notion-api:iterate"
       run: |
-        if [ -z "${{ inputs.references-diff }}" ]; then
-          paperpile-notion articles:sync ${{ inputs.references }} -t ${{ inputs.token }}
-        else
-          paperpile-notion articles:sync ${{ inputs.references }} -t ${{ inputs.token }} -d ${{ inputs.references-diff }}
-        fi
+        paperpile-notion articles:sync ${{ inputs.references }} ${{ inputs.references-diff }} -t ${{ inputs.token }}
 
     - name: "Clean Author's Database"
       shell: "bash"
       env:
         DEBUG: "@jitl/notion-api:cms:cache,@jtil/notion-api:children,@jitl/notion-api:iterate"
-      run: "paperpile-notion authors:clean ${{ inputs.references }} -t ${{ inputs.token }}"
+      run: |
+        paperpile-notion authors:clean ${{ inputs.references }} -t ${{ inputs.token }}
 
     - name: "Clean Article's Database"
       shell: "bash"
       env:
         DEBUG: "@jitl/notion-api:cms:cache,@jtil/notion-api:children,@jitl/notion-api:iterate"
-      run: "paperpile-notion articles:clean ${{ inputs.references }} -t ${{ inputs.token }}"
+      run: |
+        paperpile-notion articles:clean ${{ inputs.references }} -t ${{ inputs.token }}
 
     - if: always()
       name: "Upload `paperpile-notion` cache as Artifact"

--- a/src/base.ts
+++ b/src/base.ts
@@ -83,9 +83,11 @@ abstract class BaseCommand extends Command {
 
     let bibtex: BibTeXDB
     const currBibTeX: BibTeXDB = readBibTeX(args.bibtexPath)
+    console.log(`Found ${_.keys(currBibTeX).length} entries`)
     if (flags.diff) {
       const prevBibTeX: BibTeXDB = readBibTeX(flags.diff)
       bibtex = diffBibTeX(prevBibTeX, currBibTeX)
+      console.log(`Reduced to ${_.keys(bibtex).length} entries`)
     } else {
       bibtex = currBibTeX
     }

--- a/src/bibtex.ts
+++ b/src/bibtex.ts
@@ -9,19 +9,19 @@ const parseKeywords = (keywords: string[] | undefined) => {
     return {keywords: []}
   }
 
-  let status = _.find(keywords, (k: string) => k.startsWith(`status:`))
+  let status: string = keywords.find((k: string) => k.startsWith(`status:`))
   keywords = keywords.filter((k: string) => k.startsWith("status:"))
   status = status?.replace(/status:/, ``)
 
-  let topics = keywords.filter((k: string) => k.startsWith(`topic:`))
+  let topics: string[] = keywords.filter((k: string) => k.startsWith(`topic:`))
   keywords = keywords.filter((k: string) => !topics.includes(k))
   topics = topics?.map((t: string) => t.replace(/topic:/, ``))
 
-  let fields = keywords.filter((k: string) => k.startsWith(`field:`))
+  let fields: string[] = keywords.filter((k: string) => k.startsWith(`field:`))
   keywords = keywords.filter((k: string) => !fields.includes(k))
   fields = fields?.map((t: string) => t.replace(/field:/, ``))
 
-  let methods = keywords.filter((k: string) => k.startsWith(`method:`))
+  let methods: string[] = keywords.filter((k: string) => k.startsWith(`method:`))
   keywords = keywords.filter((k: string) => !methods.includes(k))
   methods = methods?.map((t: string) => t.replace(/method:/, ``))
 
@@ -61,6 +61,19 @@ export const readBibTeX = (path: string) => {
 
     return obj
   }, entries)
+}
+
+export const diffBibTeX = (prev: BibTeXDB, curr: BibTeXDB): BibTeXDB => {
+  return _.keys(curr).map((key: string) => {
+    if (!prev[key]) { // New BibTeX entry
+      return key
+    } else if (!_.isEqual(prev[key], curr[key])) { // Updated BibTeX entry
+      return key
+    }
+  }).filter(k => k).reduce((obj: BibTeXDB, key: string) => {
+    obj[key] = curr[key]
+    return obj
+  }, {})
 }
 
 const truncate = (str: string, maxlen: number = 100) => {


### PR DESCRIPTION
Running `sync` on a whole library is really only useful for the initial sync to Notion. Otherwise, diffs are really what need to be synced. This PR adds that support.